### PR TITLE
Force writing the file to analyze before runnning Detekt

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektAnnotator.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/DetektAnnotator.kt
@@ -3,15 +3,20 @@ package io.gitlab.arturbosch.detekt
 import com.intellij.ide.projectView.impl.ProjectRootsUtil
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.ExternalAnnotator
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.fileEditor.FileDocumentManager
+import com.intellij.openapi.util.Computable
 import com.intellij.openapi.util.TextRange
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiFile
+import com.intellij.psi.PsiManager
 import io.gitlab.arturbosch.detekt.api.Finding
 import io.gitlab.arturbosch.detekt.api.TextLocation
 import io.gitlab.arturbosch.detekt.api.YamlConfig
 import io.gitlab.arturbosch.detekt.config.DetektConfigStorage
 import io.gitlab.arturbosch.detekt.core.DetektFacade
 import io.gitlab.arturbosch.detekt.core.ProcessingSettings
+import java.io.File
 import java.nio.file.Paths
 import java.util.concurrent.ForkJoinPool
 
@@ -23,11 +28,23 @@ class DetektAnnotator : ExternalAnnotator<PsiFile, List<Finding>>() {
 	override fun collectInformation(file: PsiFile): PsiFile = file
 
 	override fun doAnnotate(collectedInfo: PsiFile): List<Finding> {
-		val configuration = DetektConfigStorage.instance(collectedInfo.project)
+		WriteCommandAction.runWriteCommandAction(collectedInfo.project, object : Computable<Boolean> {
+			override fun compute(): Boolean {
+				val documentManager = FileDocumentManager.getInstance()
+				val document = documentManager.getDocument(collectedInfo.virtualFile)
+				if (document != null) {
+					documentManager.saveDocument(document)
+					return false
+				}
+				return true
+			}
+		})
 
+		val configuration = DetektConfigStorage.instance(collectedInfo.project)
 		if (configuration.enableDetekt) {
 			return if (ProjectRootsUtil.isInTestSource(collectedInfo)
-					&& !configuration.checkTestFiles) {
+				&& !configuration.checkTestFiles
+			) {
 				emptyList()
 			} else {
 				runDetekt(collectedInfo, configuration)
@@ -36,18 +53,21 @@ class DetektAnnotator : ExternalAnnotator<PsiFile, List<Finding>>() {
 		return emptyList()
 	}
 
-	private fun runDetekt(collectedInfo: PsiFile,
-						  configuration: DetektConfigStorage): List<Finding> {
+	private fun runDetekt(
+		collectedInfo: PsiFile,
+		configuration: DetektConfigStorage
+	): List<Finding> {
 		val virtualFile = collectedInfo.originalFile.virtualFile
 		val settings = processingSettings(virtualFile, configuration)
 		val detektion = DetektFacade.create(settings).run()
 		return detektion.findings.flatMap { it.value }
 	}
 
-	override fun apply(file: PsiFile,
-					   annotationResult: List<Finding>,
-					   holder: AnnotationHolder) {
-
+	override fun apply(
+		file: PsiFile,
+		annotationResult: List<Finding>,
+		holder: AnnotationHolder
+	) {
 		val configuration = DetektConfigStorage.instance(file.project)
 		annotationResult.forEach {
 			val textRange = it.charPosition.toTextRange()
@@ -61,21 +81,23 @@ class DetektAnnotator : ExternalAnnotator<PsiFile, List<Finding>>() {
 	}
 
 	private fun TextLocation.toTextRange(): TextRange = TextRange.create(
-			start, end
+		start, end
 	)
 
-	private fun processingSettings(virtualFile: VirtualFile,
-								   configStorage: DetektConfigStorage): ProcessingSettings {
+	private fun processingSettings(
+		virtualFile: VirtualFile,
+		configStorage: DetektConfigStorage
+	): ProcessingSettings {
 		return if (configStorage.rulesPath.isEmpty()) {
 			ProcessingSettings(
-					project = Paths.get(virtualFile.path),
-					executorService = ForkJoinPool.commonPool()
+				project = Paths.get(virtualFile.path),
+				executorService = ForkJoinPool.commonPool()
 			)
 		} else {
 			ProcessingSettings(
-					project = Paths.get(virtualFile.path),
-					config = YamlConfig.load(Paths.get(configStorage.rulesPath)),
-					executorService = ForkJoinPool.commonPool()
+				project = Paths.get(virtualFile.path),
+				config = YamlConfig.load(Paths.get(configStorage.rulesPath)),
+				executorService = ForkJoinPool.commonPool()
 			)
 		}
 	}


### PR DESCRIPTION
This addresses issue #7 

While Detekt runs really fast the warnings were not up to date since Detekt wasn't able to see the latest changes since the file wasn't written yet.

This forces write to disk before running Detekt.

I noticed some reformats - but used the Kotlin Style Guide code format in IDEA. Hope that's fine for you.

An even better way to solve this would be to scan the in-memory representation of the file instead of forcing a write. That however would be a bigger change in Detekt itself.