### PR TITLE
Issue #25: Upgrade embedded Detekt to 1.0.0-RC13

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 ### Changelog
 
+#### 0.2.1
+- Upgrade detekt enging to 1.0.0-RC13
+
 #### 0.2.0
 
 - Uses detekt 1.0.0-RC10 as engine baseline

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-detektIntellijPluginVersion=0.2.0
-detektVersion=1.0.0-RC10
+detektIntellijPluginVersion=0.2.1
+detektVersion=1.0.0-RC13
 kotlinVersion=1.3.0
 
 systemProp.sonar.host.url=http://localhost:9000


### PR DESCRIPTION
@arturbosch Please let me know if I missed anything here. Tested it by installing locally into 2019.1 EAP and no issues. Reports errors/fixes of RC13.