### PR TITLE
Put detekt plugin config in a separate file to ease sharing

### DIFF
--- a/src/main/kotlin/io/gitlab/arturbosch/detekt/config/DetektConfigStorage.kt
+++ b/src/main/kotlin/io/gitlab/arturbosch/detekt/config/DetektConfigStorage.kt
@@ -13,7 +13,7 @@ import com.intellij.util.xmlb.annotations.Tag
  */
 @State(
     name = "DetektProjectConfiguration",
-    storages = [(Storage(StoragePathMacros.WORKSPACE_FILE))]
+    storages = [Storage("detekt.xml")]
 )
 class DetektConfigStorage : PersistentStateComponent<DetektConfigStorage> {
 


### PR DESCRIPTION
Fixes #13

:warning: there is no migration of previous configuration but I doubt it's critical, is it?